### PR TITLE
Add Github action for running pre-commit as CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,48 @@
+name: Pre-commit on all files
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    # Make sure we have a postgres DB available as we need it to run our tests.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: f1data
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13.3'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install pre-commit
+        run: uv tool install pre-commit
+
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: f1data
+          DATABASE_URL: postgresql://postgres@localhost/f1data


### PR DESCRIPTION
So that we can double check everything complies with our requirements.

This should also catch anything in case pre-commit hooks aren't enabled.

Now that I'm working with PRs a little more it seems odd to not have a CI check. I also wanted to make sure I didn't accidentally miss anything as I do sometimes intentionally skip pre-commit checks, especially as ty is currently not set up well in pre-commit (or has bugs which is possible as it's new).